### PR TITLE
Force portrait mode at all times

### DIFF
--- a/src/ProjectSettings/ProjectSettings.asset
+++ b/src/ProjectSettings/ProjectSettings.asset
@@ -8,7 +8,7 @@ PlayerSettings:
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
   AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  defaultScreenOrientation: 0
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60


### PR DESCRIPTION
This changes the default screen behavior for android so it stays in portrait mode and doesn't rotate