### PR TITLE
Remove useless overshadowing of transform

### DIFF
--- a/src/Assets/Scripts/Player/ScreenShakeController.cs
+++ b/src/Assets/Scripts/Player/ScreenShakeController.cs
@@ -6,8 +6,6 @@ public class ScreenShakeController : MonoBehaviour
 {
     public static ScreenShakeController instance;
 
-    private Transform transform;
-
     private float shakeDuration = 0f;
 
     [SerializeField]
@@ -21,14 +19,6 @@ public class ScreenShakeController : MonoBehaviour
     private void Start()
     {
         instance = this;
-    }
-
-    private void Awake()
-    {
-        if (transform == null)
-        {
-            transform = GetComponent(typeof(Transform)) as Transform;
-        }
     }
 
     private void OnEnable()
@@ -52,8 +42,6 @@ public class ScreenShakeController : MonoBehaviour
 
     public void TriggerShake(float shakeTime)
     {
-      
         shakeDuration = shakeTime;
-
     }
 }


### PR DESCRIPTION
We overshadow transform with transform. That's unnecessary and shows a warning in unity log and I am sick and tired of seeing it