### PR TITLE
Remove unused damage variable

### DIFF
--- a/src/Assets/Scripts/Player/Bullet.cs
+++ b/src/Assets/Scripts/Player/Bullet.cs
@@ -7,8 +7,6 @@ public class Bullet : MonoBehaviour
     [SerializeField]
     private float speed = 20f;
     [SerializeField]
-    private int damage = 1;
-    [SerializeField]
     private Rigidbody2D rb;
 
     [SerializeField]


### PR DESCRIPTION
we have nothing that takes more than one hit and code was not written with that in mind. removing because i am tired of seeing that stupid warning