### PR TITLE
Fix player death controls

### DIFF
--- a/src/Assets/Scripts/Player/PlayerController.cs
+++ b/src/Assets/Scripts/Player/PlayerController.cs
@@ -37,7 +37,7 @@ public class PlayerController : MonoBehaviour
         ClampPosition();
     }
 
-  
+
 
     void FixedUpdate() {
         float direction;
@@ -46,8 +46,15 @@ public class PlayerController : MonoBehaviour
         }else{
             direction = axis.x;
         }
-        Move(direction);
-        Rotate(direction);
+        if(GameController.instance.IsRunning())
+        {
+            Move(direction);
+            Rotate(direction);
+        }
+        else
+        {
+            rb2D.velocity = new Vector2(0,0);
+        }
     }
 
     public void OnMove(InputValue input){

--- a/src/Assets/Scripts/Player/Shooting.cs
+++ b/src/Assets/Scripts/Player/Shooting.cs
@@ -20,7 +20,10 @@ public class Shooting : MonoBehaviour
 
     private void OnFire(){
         Vector2 position = Input.mousePosition;
-        Fire(position);
+        if(gameController.IsRunning())
+        {
+            Fire(position);
+        }
     }
 
     private void Fire(Vector2 screenPosition) {


### PR DESCRIPTION
Fixes some bugs regarding player death.
Shooting after death is now no longer possible.
Moving after death is now no longer possible.
Velocity is set to 0 upon death.